### PR TITLE
Implement responsive design for JSF views

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,6 @@ mvn clean package
 mvn spring-boot:run
 ```
 La aplicacion quedara disponible en `http://localhost:8080`.
+
+## Integracion JSF
+La aplicacion usa JavaServer Faces con MyFaces y CDI. El bean `JsfInitializer` registra programaticamente el `FacesServlet` y los listeners necesarios para que los enlaces y formularios funcionen correctamente. Si la navegacion parece estatica, asegúrate de ejecutar la aplicacion a traves de Spring Boot para que este inicializador se ejecute.

--- a/src/main/java/com/example/smartwebapp/config/JsfInitializer.java
+++ b/src/main/java/com/example/smartwebapp/config/JsfInitializer.java
@@ -1,0 +1,43 @@
+package com.example.smartwebapp.config;
+
+import jakarta.faces.webapp.FacesServlet;
+import org.apache.myfaces.webapp.StartupServletContextListener;
+import org.jboss.weld.environment.servlet.Listener;
+import org.springframework.boot.web.servlet.ServletContextInitializer;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
+import org.springframework.boot.web.servlet.ServletListenerRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+
+@Configuration
+public class JsfInitializer implements ServletContextInitializer {
+
+    @Override
+    public void onStartup(ServletContext servletContext) throws ServletException {
+        servletContext.setInitParameter("jakarta.faces.PROJECT_STAGE", "Development");
+        servletContext.setInitParameter("jakarta.faces.FACELETS_REFRESH_PERIOD", "0");
+        servletContext.setInitParameter("jakarta.faces.DEFAULT_SUFFIX", ".xhtml");
+        servletContext.setInitParameter("jakarta.faces.WEBAPP_RESOURCES_DIRECTORY", "/resources");
+    }
+
+    @Bean
+    public ServletRegistrationBean<FacesServlet> facesServlet() {
+        ServletRegistrationBean<FacesServlet> bean = new ServletRegistrationBean<>(new FacesServlet(), "*.xhtml");
+        bean.setLoadOnStartup(1);
+        bean.setName("FacesServlet");
+        return bean;
+    }
+
+    @Bean
+    public ServletListenerRegistrationBean<StartupServletContextListener> startupListener() {
+        return new ServletListenerRegistrationBean<>(new StartupServletContextListener());
+    }
+
+    @Bean
+    public ServletListenerRegistrationBean<Listener> weldListener() {
+        return new ServletListenerRegistrationBean<>(new Listener());
+    }
+}

--- a/src/main/webapp/index.xhtml
+++ b/src/main/webapp/index.xhtml
@@ -2,7 +2,33 @@
 <!-- Página de inicio con enlaces a las secciones principales -->
 <html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:h="https://jakarta.ee/xml/ns/jakartaee">
-<h:head><title>SmartWebApp - Home</title></h:head>
+<h:head>
+    <title>SmartWebApp - Home</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+        }
+        nav ul {
+            list-style: none;
+            padding: 0;
+            display: flex;
+            gap: 10px;
+        }
+        nav li {
+            flex: 1;
+        }
+        @media (max-width: 768px) {
+            nav ul {
+                flex-direction: column;
+            }
+            nav li {
+                margin-bottom: 5px;
+            }
+        }
+    </style>
+</h:head>
 <h:body>
     <h1>SmartWebApp</h1>
     <p>Bienvenido a la aplicación de gestión de usuarios y tareas.</p>

--- a/src/main/webapp/tasks.xhtml
+++ b/src/main/webapp/tasks.xhtml
@@ -5,18 +5,25 @@
       xmlns:f="https://jakarta.ee/xml/ns/jakartaee">
 <h:head>
     <title>SmartWebApp - Tareas</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         .form-section { background: #f5f5f5; padding: 15px; margin: 10px 0; border-radius: 5px; }
         .data-table { border-collapse: collapse; width: 100%; margin-top: 20px; }
         .data-table th, .data-table td { border: 1px solid #ddd; padding: 8px; text-align: left; }
         .data-table th { background-color: #4CAF50; color: white; }
-        .form-field { margin: 5px 0; }
-        .form-field label { display: inline-block; width: 120px; }
+        .form-field { margin: 5px 0; display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+        .form-field label { width: 120px; }
         .btn { background-color: #4CAF50; color: white; padding: 8px 16px; border: none; border-radius: 4px; cursor: pointer; }
         .btn:hover { background-color: #45a049; }
-        .navigation { margin-bottom: 20px; }
-        .navigation a { margin-right: 15px; text-decoration: none; color: #4CAF50; }
+        .navigation { margin-bottom: 20px; display: flex; gap: 10px; flex-wrap: wrap; }
+        .navigation a { text-decoration: none; color: #4CAF50; }
+        .table-container { overflow-x: auto; }
+        @media (max-width: 768px) {
+            .form-field { flex-direction: column; align-items: stretch; }
+            .form-field label { width: auto; margin-bottom: 5px; }
+            .navigation { flex-direction: column; }
+        }
         select, input[type="text"] { padding: 5px; margin-left: 10px; }
     </style>
 </h:head>
@@ -50,20 +57,22 @@
     </div>
     
     <h2>Lista de Tareas</h2>
-    <h:dataTable value="#{taskBean.tasks}" var="t" styleClass="data-table" rendered="#{not empty taskBean.tasks}">
-        <h:column>
-            <f:facet name="header">ID</f:facet>
-            #{t.id}
-        </h:column>
-        <h:column>
-            <f:facet name="header">Descripción</f:facet>
-            #{t.description}
-        </h:column>
-        <h:column>
-            <f:facet name="header">Usuario Asignado</f:facet>
-            #{t.user.name}
-        </h:column>
-    </h:dataTable>
+    <div class="table-container">
+        <h:dataTable value="#{taskBean.tasks}" var="t" styleClass="data-table" rendered="#{not empty taskBean.tasks}">
+            <h:column>
+                <f:facet name="header">ID</f:facet>
+                #{t.id}
+            </h:column>
+            <h:column>
+                <f:facet name="header">Descripción</f:facet>
+                #{t.description}
+            </h:column>
+            <h:column>
+                <f:facet name="header">Usuario Asignado</f:facet>
+                #{t.user.name}
+            </h:column>
+        </h:dataTable>
+    </div>
     
     <h:panelGroup rendered="#{empty taskBean.tasks}">
         <p>No hay tareas registradas.</p>

--- a/src/main/webapp/users.xhtml
+++ b/src/main/webapp/users.xhtml
@@ -5,18 +5,25 @@
       xmlns:f="https://jakarta.ee/xml/ns/jakartaee">
 <h:head>
     <title>SmartWebApp - Usuarios</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <style>
         body { font-family: Arial, sans-serif; margin: 20px; }
         .form-section { background: #f5f5f5; padding: 15px; margin: 10px 0; border-radius: 5px; }
         .data-table { border-collapse: collapse; width: 100%; margin-top: 20px; }
         .data-table th, .data-table td { border: 1px solid #ddd; padding: 8px; text-align: left; }
         .data-table th { background-color: #4CAF50; color: white; }
-        .form-field { margin: 5px 0; }
-        .form-field label { display: inline-block; width: 100px; }
+        .form-field { margin: 5px 0; display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+        .form-field label { width: 100px; }
         .btn { background-color: #4CAF50; color: white; padding: 8px 16px; border: none; border-radius: 4px; cursor: pointer; }
         .btn:hover { background-color: #45a049; }
-        .navigation { margin-bottom: 20px; }
-        .navigation a { margin-right: 15px; text-decoration: none; color: #4CAF50; }
+        .navigation { margin-bottom: 20px; display: flex; gap: 10px; flex-wrap: wrap; }
+        .navigation a { text-decoration: none; color: #4CAF50; }
+        .table-container { overflow-x: auto; }
+        @media (max-width: 768px) {
+            .form-field { flex-direction: column; align-items: stretch; }
+            .form-field label { width: auto; margin-bottom: 5px; }
+            .navigation { flex-direction: column; }
+        }
     </style>
 </h:head>
 <h:body>
@@ -42,16 +49,18 @@
     </div>
     
     <h2>Lista de Usuarios</h2>
-    <h:dataTable value="#{userBean.users}" var="u" styleClass="data-table" rendered="#{not empty userBean.users}">
-        <h:column>
-            <f:facet name="header">ID</f:facet>
-            #{u.id}
-        </h:column>
-        <h:column>
-            <f:facet name="header">Nombre</f:facet>
-            #{u.name}
-        </h:column>
-    </h:dataTable>
+    <div class="table-container">
+        <h:dataTable value="#{userBean.users}" var="u" styleClass="data-table" rendered="#{not empty userBean.users}">
+            <h:column>
+                <f:facet name="header">ID</f:facet>
+                #{u.id}
+            </h:column>
+            <h:column>
+                <f:facet name="header">Nombre</f:facet>
+                #{u.name}
+            </h:column>
+        </h:dataTable>
+    </div>
     
     <h:panelGroup rendered="#{empty userBean.users}">
         <p>No hay usuarios registrados.</p>

--- a/src/test/java/com/example/smartwebapp/UserServiceTests.java
+++ b/src/test/java/com/example/smartwebapp/UserServiceTests.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.context.annotation.Import;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -19,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = Replace.NONE)
+@Import(UserService.class)
 public class UserServiceTests {
 
     /** Servicio de usuarios inyectado para las pruebas. */


### PR DESCRIPTION
## Summary
- add mobile viewport and responsive CSS to index.xhtml
- update users.xhtml with responsive form and table
- update tasks.xhtml with responsive styles
- register FacesServlet and listeners with JsfInitializer
- document the JSF initializer in README
- fix UserServiceTests configuration

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857d55e23ac8330ba9ecd34b825d6d6